### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Rogério Brito <rbrito@ime.usp.br>
 Build-Depends:
  debhelper (>= 12~),
- debhelper-compat (= 12),
+ debhelper-compat (= 13),
  rdfind,
  symlinks
 Standards-Version: 4.5.0

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends:
  debhelper-compat (= 13),
  rdfind,
  symlinks
-Standards-Version: 4.5.0
+Standards-Version: 4.6.0
 Homepage: https://launchpad.net/~tiheum/+archive/equinox
 Vcs-Git: https://github.com/rbrito/pkg-faenza-icon-theme.git
 Vcs-Browser: https://github.com/rbrito/pkg-faenza-icon-theme

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,2 @@
+---
+Repository-Browse: https://code.launchpad.net/~tiheum


### PR DESCRIPTION
Fix some issues reported by lintian

* Bump debhelper from old 12 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))

* Set upstream metadata fields: Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing))

* Update standards version to 4.6.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/faenza-icon-theme/83d8d592-a05f-4d5a-a501-eba165413b1f.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/83d8d592-a05f-4d5a-a501-eba165413b1f/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/83d8d592-a05f-4d5a-a501-eba165413b1f/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/83d8d592-a05f-4d5a-a501-eba165413b1f/diffoscope)).
